### PR TITLE
Have the winfs-injector read the rootfs image tag from config/blobs.yml

### DIFF
--- a/winfsinjector/fakes/release_creator.go
+++ b/winfsinjector/fakes/release_creator.go
@@ -2,20 +2,20 @@
 package fakes
 
 import (
-	sync "sync"
+	"sync"
 )
 
 type ReleaseCreator struct {
-	CreateReleaseStub        func(string, string, string, string, string, string, string) error
+	CreateReleaseStub        func(releaseName, imageName, releaseDir, tarballPath, imageTag, registry, version string) error
 	createReleaseMutex       sync.RWMutex
 	createReleaseArgsForCall []struct {
-		arg1 string
-		arg2 string
-		arg3 string
-		arg4 string
-		arg5 string
-		arg6 string
-		arg7 string
+		releaseName string
+		imageName   string
+		releaseDir  string
+		tarballPath string
+		imageTag    string
+		registry    string
+		version     string
 	}
 	createReleaseReturns struct {
 		result1 error
@@ -27,28 +27,27 @@ type ReleaseCreator struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *ReleaseCreator) CreateRelease(arg1 string, arg2 string, arg3 string, arg4 string, arg5 string, arg6 string, arg7 string) error {
+func (fake *ReleaseCreator) CreateRelease(releaseName string, imageName string, releaseDir string, tarballPath string, imageTag string, registry string, version string) error {
 	fake.createReleaseMutex.Lock()
 	ret, specificReturn := fake.createReleaseReturnsOnCall[len(fake.createReleaseArgsForCall)]
 	fake.createReleaseArgsForCall = append(fake.createReleaseArgsForCall, struct {
-		arg1 string
-		arg2 string
-		arg3 string
-		arg4 string
-		arg5 string
-		arg6 string
-		arg7 string
-	}{arg1, arg2, arg3, arg4, arg5, arg6, arg7})
-	fake.recordInvocation("CreateRelease", []interface{}{arg1, arg2, arg3, arg4, arg5, arg6, arg7})
+		releaseName string
+		imageName   string
+		releaseDir  string
+		tarballPath string
+		imageTag    string
+		registry    string
+		version     string
+	}{releaseName, imageName, releaseDir, tarballPath, imageTag, registry, version})
+	fake.recordInvocation("CreateRelease", []interface{}{releaseName, imageName, releaseDir, tarballPath, imageTag, registry, version})
 	fake.createReleaseMutex.Unlock()
 	if fake.CreateReleaseStub != nil {
-		return fake.CreateReleaseStub(arg1, arg2, arg3, arg4, arg5, arg6, arg7)
+		return fake.CreateReleaseStub(releaseName, imageName, releaseDir, tarballPath, imageTag, registry, version)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.createReleaseReturns
-	return fakeReturns.result1
+	return fake.createReleaseReturns.result1
 }
 
 func (fake *ReleaseCreator) CreateReleaseCallCount() int {
@@ -57,22 +56,13 @@ func (fake *ReleaseCreator) CreateReleaseCallCount() int {
 	return len(fake.createReleaseArgsForCall)
 }
 
-func (fake *ReleaseCreator) CreateReleaseCalls(stub func(string, string, string, string, string, string, string) error) {
-	fake.createReleaseMutex.Lock()
-	defer fake.createReleaseMutex.Unlock()
-	fake.CreateReleaseStub = stub
-}
-
 func (fake *ReleaseCreator) CreateReleaseArgsForCall(i int) (string, string, string, string, string, string, string) {
 	fake.createReleaseMutex.RLock()
 	defer fake.createReleaseMutex.RUnlock()
-	argsForCall := fake.createReleaseArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5, argsForCall.arg6, argsForCall.arg7
+	return fake.createReleaseArgsForCall[i].releaseName, fake.createReleaseArgsForCall[i].imageName, fake.createReleaseArgsForCall[i].releaseDir, fake.createReleaseArgsForCall[i].tarballPath, fake.createReleaseArgsForCall[i].imageTag, fake.createReleaseArgsForCall[i].registry, fake.createReleaseArgsForCall[i].version
 }
 
 func (fake *ReleaseCreator) CreateReleaseReturns(result1 error) {
-	fake.createReleaseMutex.Lock()
-	defer fake.createReleaseMutex.Unlock()
 	fake.CreateReleaseStub = nil
 	fake.createReleaseReturns = struct {
 		result1 error
@@ -80,8 +70,6 @@ func (fake *ReleaseCreator) CreateReleaseReturns(result1 error) {
 }
 
 func (fake *ReleaseCreator) CreateReleaseReturnsOnCall(i int, result1 error) {
-	fake.createReleaseMutex.Lock()
-	defer fake.createReleaseMutex.Unlock()
 	fake.CreateReleaseStub = nil
 	if fake.createReleaseReturnsOnCall == nil {
 		fake.createReleaseReturnsOnCall = make(map[int]struct {

--- a/winfsinjector/release_creator.go
+++ b/winfsinjector/release_creator.go
@@ -14,13 +14,7 @@ import (
 
 type ReleaseCreator struct{}
 
-func (rc ReleaseCreator) CreateRelease(releaseName, imageName, releaseDir, tarballPath, imageTagPath, registry, version string) error {
-	tagData, err := ioutil.ReadFile(imageTagPath)
-	if err != nil {
-		return err
-	}
-	imageTag := string(tagData)
-
+func (rc ReleaseCreator) CreateRelease(releaseName, imageName, releaseDir, tarballPath, imageTag, registry, version string) error {
 	hLogger := log.New(os.Stdout, "", 0)
 	releaseBlob := filepath.Join(releaseDir, "blobs", releaseName)
 


### PR DESCRIPTION
As opposed to a submodule within the release. This allow for the
submodule to be removed and allows for maintaining a single source
of truth with respect to the appropriate rootfs for the release.

[#171671128]

This PR attempts to address the same issue as https://github.com/pivotal-cf/winfs-injector/pull/4