### PR TITLE
allow winfs injector to display a warning if the tile is already injected

### DIFF
--- a/winfsinjector/application.go
+++ b/winfsinjector/application.go
@@ -79,8 +79,11 @@ func (a Application) Run(inputTile, outputTile, registry, workingDir string) err
 
 	if len(files) > 1 {
 		return errors.New("there is more than one file system embedded in the tile; please contact the tile authors to fix")
-	} else if len(files) == 0 {
-		return errors.New("there is no file system embedded in the tile; please contact the tile authors to fix")
+	}
+
+	if len(files) == 0 {
+		fmt.Println("The file system has already been injected in the tile; skipping injection")
+		return nil
 	}
 
 	e := files[0]

--- a/winfsinjector/application.go
+++ b/winfsinjector/application.go
@@ -73,8 +73,8 @@ func (a Application) Run(inputTile, outputTile, registry, workingDir string) err
 	// find what the embedded directory is
 	embedDirectory := filepath.Join(extractedTileDir, "embed")
 	files, err := readDir(embedDirectory)
-	if err != nil {
-		return err
+	if _, err := os.Stat(embedDirectory); os.IsNotExist(err) {
+		return errors.New("there is no file system embedded in the tile; please contact the tile authors to fix")
 	}
 
 	if len(files) > 1 {


### PR DESCRIPTION
Backfilled some missing tests to feel more confident about the changes. 
Moved the check for a file system earlier in the code, as the nice error message did not seem to be displaying. 
Some manual tests I ran:
```bash
#original behavior of the injector based on last release
$winfs-injector --input-tile ~/Downloads/p-event-alerts-1.2.10-build.1.pivotal --output-tile ~/Downloads/event-alerts-injected.pivota
open /var/folders/_t/_s5_2hmn3j13klympv_h43d40000gn/T/663105679/extracted-tile/embed: no such file or directory
```

```bash
#same test but run with a newly compiled binary
$./winfs-injector --input-tile ~/Downloads/p-event-alerts-1.2.10-build.1.pivotal --output-tile ~/Downloads/event-alerts-injected.pivota
there is no file system embedded in the tile; please contact the tile authors to fix
```

```bash
#original behavior using a tile that has already been injected
$ winfs-injector --input-tile ~/Downloads/pas-windows-injected.pivotal --output-tile ~/Downloads/pas-windows-injected.pivotal
there is no file system embedded in the tile; please contact the tile authors to fix
```


```bash
#same test, but with newly compiled binary
$./winfs-injector --input-tile ~/Downloads/pas-windows-injected.pivotal --output-tile ~/Downloads/pas-windows-injected.pivotal
The file system has already been injected in the tile; skipping injection
```

```bash
#running winfs-injector binary against an uninjected, compatible tile
$./winfs-injector --input-tile ~/Downloads/pas-windows-2.11.0-build.77.pivotal\ copy --output-tile ~/Downloads/pas-windows-injected.pivotal

Downloading image: cloudfoundry/windows2016fs with tag: 2019.0.56 from registry: https://registry.hub.docker.com
Downloading 33 layers...
Layer diffID: a7ba3db2, sha256: 4612f6d0 begin
Layer diffID: 1a7b837f, sha256: 36439989 begin
Layer diffID: 9fc53efb, sha256: 712cc260 begin
Layer diffID: bfaf5c31, sha256: 8af065cd begin
....
```