### PR TITLE
make bumping Go easier

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,14 +16,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version-file: ./go.mod
 
       - name: Build
         run: go build -v ./...
@@ -32,10 +32,11 @@ jobs:
         run: go test --covermode=atomic --coverprofile=winfs-injector-${{ github.sha }}-unit-test-code-coverage.out -v ./...
 
       - name: Archive Unit Test Code Coverage Output
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Unit Test Code Coverage Output
           path: winfs-injector-${{ github.sha }}-unit-test-code-coverage.out
+          overwrite: true
 
       - if: startsWith(github.ref, 'refs/tags/')
         name: Login to Docker Hub


### PR DESCRIPTION
Now you do not need to update the workflow when you bumpg Go. You just need to run something like `go mod edit -go=1.22 && go mod tidy && git add go.* && git commit -m 'bump Go' && git push` with the latest Go version

This change also bumps the versions of the Checkout and Unit Test Output steps