### PR TITLE
feat: Updated CI to not push winfs-injector image to GCR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,14 +46,6 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - if: startsWith(github.ref, 'refs/tags/')
-        name: Login to GCR
-        uses: docker/login-action@v2
-        with:
-          registry: gcr.io
-          username: _json_key
-          password: ${{ secrets.TAS_PPE_GCR_SERVICE_JSON_KEY }}
-
-      - if: startsWith(github.ref, 'refs/tags/')
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -51,8 +51,6 @@ dockers:
 - image_templates:
   - "pivotalcfreleng/winfs-injector:latest"
   - "pivotalcfreleng/winfs-injector:{{ .Tag }}"
-  - "gcr.io/tas-ppe/pivotalcfreleng/winfs-injector:latest"
-  - "gcr.io/tas-ppe/pivotalcfreleng/winfs-injector:{{ .Tag }}"
   skip_push: "false"
   build_flag_templates:
   - "--label=org.opencontainers.image.created={{.Date}}"


### PR DESCRIPTION
[TNZ-36076] - [GCP Migration]: Migrate TAS Releng GCP projects to internal BSG GCP JIRA Link - https://vmw-jira.broadcom.net/browse/TNZ-36076 Updated on: 07-Apr-2025

Authored-by: Ramkumar Vengadakrishnan <ramkumar.vengadakrishnan@broadcom.com>